### PR TITLE
Refactor and edit:

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,7 +2,7 @@
 """This module instantiates an object of class FileStorage"""
 from os import environ
 
-if environ['HBNB_TYPE_STORAGE'] == 'db':
+if environ.get('HBNB_TYPE_STORAGE') == 'db':
     from models.engine.db_storage import DBStorage
     storage = DBStorage()
     storage.reload()
@@ -10,3 +10,13 @@ else:
     from models.engine.file_storage import FileStorage
     storage = FileStorage()
     storage.reload()
+
+class_dict = {
+    "Amenity": "amenity",
+    "BaseModel": "base_model",
+    "City": "city",
+    "Place": "place",
+    "Review": "review",
+    "State": "state",
+    "User": "user"
+}

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """This module defines a base class for all models in our hbnb clone"""
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, String, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 import uuid
 from datetime import datetime
@@ -17,7 +17,6 @@ class BaseModel:
     def __init__(self, *args, **kwargs):
         """Instatntiates a new model"""
         if not kwargs:
-            # from models import storage
             self.id = str(uuid.uuid4())
             self.created_at = datetime.now()
             self.updated_at = datetime.now()
@@ -31,7 +30,7 @@ class BaseModel:
 
     def __str__(self):
         """Returns a string representation of the instance"""
-        cls = (str(type(self)).split('.')[-1]).split('\'')[0]
+        cls = self.__class__.__name__
         obj_dict = self.__dict__.copy()
         if '_sa_instance_state' in obj_dict:
             del obj_dict['_sa_instance_state']
@@ -48,8 +47,7 @@ class BaseModel:
         """Convert instance into dict format"""
         dictionary = {}
         dictionary.update(self.__dict__)
-        dictionary.update({'__class__':
-                          (str(type(self)).split('.')[-1]).split('\'')[0]})
+        dictionary.update({'__class__': self.__class__.__name__})
         dictionary['created_at'] = self.created_at.isoformat()
         dictionary['updated_at'] = self.updated_at.isoformat()
         if '_sa_instance_state' in dictionary:

--- a/models/city.py
+++ b/models/city.py
@@ -9,7 +9,8 @@ class City(BaseModel, Base):
     """ The city class, contains state ID and name """
     __tablename__ = 'cities'
     name = Column(String(128), nullable=False)
-    state_id = Column(String(60), ForeignKey('states.id'), nullable=False)
+    state_id = Column(String(60), ForeignKey('states.id', ondelete='cascade'),
+                      nullable=False)
 
     places = relationship('Place', backref='cities',
                           cascade='all, delete-orphan')

--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 """This module defines a class to manage database based
 file storage for hbnb clone"""
-# import json
 from os import environ
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
@@ -24,10 +23,11 @@ class DBStorage:
     def __init__(self):
         """Initializes a `DBStorage` object"""
         self.__engine = create_engine('mysql+mysqldb://{}:{}@{}/{}'.format(
-            environ['HBNB_MYSQL_USER'], quote_plus(environ['HBNB_MYSQL_PWD']),
-            environ['HBNB_MYSQL_HOST'], environ['HBNB_MYSQL_DB']),
+            environ.get('HBNB_MYSQL_USER'),
+            quote_plus(environ.get('HBNB_MYSQL_PWD')),
+            environ.get('HBNB_MYSQL_HOST'), environ.get('HBNB_MYSQL_DB')),
             pool_pre_ping=True)
-        if 'HBNB_ENV' in environ and environ['HBNB_ENV'] == 'test':
+        if environ.get('HBNB_ENV') == 'test':
             Base.metadata.drop_all(self.__engine)
 
     def all(self, cls=None):

--- a/models/place.py
+++ b/models/place.py
@@ -8,8 +8,10 @@ from sqlalchemy.orm import relationship
 class Place(BaseModel, Base):
     """ A place to stay """
     __tablename__ = 'places'
-    city_id = Column(String(60), ForeignKey('cities.id'), nullable=False)
-    user_id = Column(String(60), ForeignKey('users.id'), nullable=False)
+    city_id = Column(String(60), ForeignKey('cities.id', ondelete='cascade'),
+                     nullable=False)
+    user_id = Column(String(60), ForeignKey('users.id', ondelete='cascade'),
+                     nullable=False)
     name = Column(String(128), nullable=False)
     description = Column(String(1024), nullable=True)
     number_rooms = Column(Integer, nullable=False, default=0)

--- a/models/review.py
+++ b/models/review.py
@@ -7,6 +7,8 @@ from sqlalchemy import Column, ForeignKey, String
 class Review(BaseModel, Base):
     """ Review classto store review information """
     __tablename__ = 'reviews'
-    place_id = Column(String(60), ForeignKey('places.id'), nullable=False)
-    user_id = Column(String(60), ForeignKey('users.id'), nullable=False)
+    place_id = Column(String(60), ForeignKey('places.id', ondelete='cascade'),
+                      nullable=False)
+    user_id = Column(String(60), ForeignKey('users.id', ondelete='cascade'),
+                     nullable=False)
     text = Column(String(1024), nullable=False)


### PR DESCRIPTION
Change import method by using import_module in console
Remove storage.save() in console.do_create. No need for it. Added it earlier to fix failure of new objects to be retrieved in the same session while working in interactive mode.
Use environ.get() to access env variables. Used indexing before, which caused errors when keys doesn't exist.
Add ondelete=cascade for Foreign key columns, so that child table rows get deleted when parent row is deleted.